### PR TITLE
Add tests artillery, .bat scripts and warehouse functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ CRYPTO_KEY='1qazxsw23edcvfr45tgbnhy67ujmki89'
 CRYPTO_IV='1qazxsw23edcvfr4'
 CRYPTO_ALG='aes-256-cbc'
 MANDRILL_KEY='md-xXzXxXSolGyUjNdFXxXxXx'
+ARTILLERY_TEST_DB=db-xxxxxxxxxxxxx

--- a/api/warehouse.js
+++ b/api/warehouse.js
@@ -1,8 +1,9 @@
 const logger = require('./logger');
+const ApiResult = require('./ApiResult');
+const ApiError = require('./ApiError');
 
 module.exports = {
     createLocation: async function (conn, location) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
         await conn.beginTransaction();
         try {
             const sql = 'INSERT INTO location (code, description) VALUES ( ?, ?);';
@@ -12,250 +13,430 @@ module.exports = {
             }
 
             await conn.commit();
-            logger.info('Insert into location: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.createLocation(): Transaction committed');
+            return new ApiResult(200, { message: 'Location created successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.createLocation(): Error creating location: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.createLocation(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error creating location', 1, [error]);
         }
     },
 
+    /**
+     * DELETE statement locks the row deleted.
+     */
     deleteLocation: async function (conn, location) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
         await conn.beginTransaction();
         try {
             const sql = 'DELETE FROM location WHERE id = ?;';
             const deleteLocation = await conn.execute(sql, [location.id]);
             if (deleteLocation[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t delete the location');
+                throw new Error('The location does not exist.');
             }
 
             await conn.commit();
-            logger.info('Delete from location: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.deleteLocation(): Transaction committed');
+            return new ApiResult(200, { message: 'Location deleted successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.deleteLocation(): Error deleting location: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.deleteLocation(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error deleting location', 1, [error]);
         }
     },
 
-    modifyLocation: async function (conn, location, newLocation) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * Modifies the values of the location parameter.
+     * UPDATE statement locks the row updated.
+     */
+    updateLocation: async function (conn, location) {
         await conn.beginTransaction();
         try {
-            const sql = 'UPDATE location SET code = ?, description = ? WHERE id = ?;';
-            const modifyLocation = await conn.execute(sql, [newLocation.code, newLocation.description, location.id]);
+            await lockLocation(conn, location.id);
+
+            const sql = 'UPDATE location SET code = ?, description = ?, version = version + 1 WHERE id = ? AND version = ?';
+            const modifyLocation = await conn.execute(sql, [location.code, location.description, location.id, location.version]);
             if (modifyLocation[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t modify the location');
+                throw new Error('The version does not match with the location.');
             }
 
             await conn.commit();
-            logger.info('UPDATE from location: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.updateLocation(): Transaction committed');
+            return new ApiResult(200, { message: 'Location updated successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.updateLocation(): Error updating location: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.updateLocation(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error updating location', 1, [error]);
         }
     },
 
+    /**
+     * Creates a new stock
+     */
     createStock: async function (conn, stock) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
         await conn.beginTransaction();
         try {
-            const sql = 'INSERT INTO stock (quantity, location_id, product_id, unit_id) VALUES (?, ?, ?, ?);';
-            const insertIntoStock = await conn.execute(sql, [stock.quantity, stock.location_id, stock.product_id, stock.unit_id]);
-            if (insertIntoStock[0].affectedRows !== 1) {
+            await lockLocation(conn, stock.location_id);
+
+            let sql = 'INSERT INTO stock (quantity, location_id, product_id, unit_id) VALUES (?, ?, ?, ?);';
+            let resultQuery = await conn.execute(sql, [stock.quantity, stock.location_id, stock.product_id, stock.unit_id]);
+            if (resultQuery[0].affectedRows !== 1) {
                 throw new Error('Couldn\'t insert values into stock');
             }
 
+            sql = 'SELECT id FROM stock WHERE quantity = ? AND location_id = ? AND product_id = ? AND unit_id = ?';
+            resultQuery = await conn.execute(sql, [stock.quantity, stock.location_id, stock.product_id, stock.unit_id]);
+            if (resultQuery[0].length !== 1) {
+                throw new Error('Couldn\'t find the stock');
+            }
+            await registerOperation(conn, resultQuery[0][0].id, 'createStock');
+
             await conn.commit();
-            logger.info('Insert into stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.createStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock created successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.createStock(): Error creating Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.createStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error creating Stock', 1, [error]);
         }
     },
 
+    /**
+     * Deletes the stock.
+     * DELETE statement locks the row deleted.
+     */
     deleteStock: async function (conn, stock) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
         await conn.beginTransaction();
         try {
+            await lockLocation(conn, stock.location_id);
+
             const sql = 'DELETE FROM stock WHERE id = ?;';
-            const DeleteStock = await conn.execute(sql, [stock.id]);
-            if (DeleteStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t delete the stock');
+            const deleteStock = await conn.execute(sql, [stock.id]);
+            if (deleteStock[0].affectedRows !== 1) {
+                throw new Error('The stock does not exist');
             }
 
+            await registerOperation(conn, stock.id, 'deleteStock');
+
             await conn.commit();
-            logger.info('Delete from stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.deleteStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock deleted successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.deleteStock(): Error deleting Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.deleteStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error deleting Stock', 1, [error]);
         }
     },
 
-    modifyStock: async function (conn, stock, newStock) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * Updates the stock.
+     * UPDATE statement locks the row updated.
+     */
+    updateStock: async function (conn, stock) {
         await conn.beginTransaction();
         try {
-            const sql = 'UPDATE stock SET quantity = ?, location_id = ?, product_id = ?, unit_id = ? WHERE id = ?;';
-            const modidyStock = await conn.execute(sql,
-                [newStock.quantity, newStock.location_id, newStock.product_id, newStock.unit_id, stock.id]);
-            if (modidyStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t modify the stock');
+            await lockLocation(conn, stock.location_id);
+            await checkStock(conn, stock.id);
+
+            const sql = 'UPDATE stock SET quantity = ?, location_id = ?, product_id = ?, unit_id = ?, version = version + 1 WHERE id = ? AND version = ?';
+            const resultQuery = await conn.execute(sql, [stock.quantity, stock.location_id, stock.product_id, stock.unit_id, stock.id, stock.version]);
+            if (resultQuery[0].affectedRows !== 1) {
+                throw new Error('The version does not match with the stock.');
             }
+            await registerOperation(conn, stock.id, 'updateStock');
 
             await conn.commit();
-            logger.info('UPDATE from stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.updateStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock updated successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.updateStock(): Error updating Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.updateStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error updating Stock', 1, [error]);
         }
     },
 
-    fusionStock: async function (conn, destStock, origStock) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * Fusion the two stocks into one and deletes the other.
+     * @param {*} resultStock: the final destiny of the stock.
+     * @param {*} deleteStock: the stock that will be fusioned (quantity) and then deleted.
+     */
+    fusionStock: async function (conn, resultStock, deleteStock) {
         await conn.beginTransaction();
         try {
-            let sql = 'UPDATE stock SET quantity = quantity +' +
-             ' (SELECT s.quantity FROM (SELECT quantity FROM stock FOR SHARE WHERE id = ?) s) WHERE id = ?;';
-            const fusionStock = await conn.execute(sql, [origStock.id, destStock.id]);
-            if (fusionStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t fusion the stock');
+            await lockLocation(conn, resultStock.location_id);
+            await checkStock(conn, deleteStock.id);
+
+            let sql = 'UPDATE stock SET quantity = quantity + ?, version = version + 1 WHERE id = ? AND version = ?';
+            let resultQuery = await conn.execute(sql, [deleteStock.quantity, resultStock.id, resultStock.version]);
+            if (resultQuery[0].affectedRows !== 1) {
+                throw new Error('The version does not match with the stock.');
             }
+            await registerOperation(conn, resultStock.id, 'fusionStock');
 
             sql = 'DELETE FROM stock WHERE id = ?';
-            const deleteStock = await conn.execute(sql, [origStock.id]);
-            if (deleteStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t delete the stock');
+            resultQuery = await conn.execute(sql, [deleteStock.id]);
+            if (resultQuery[0].affectedRows !== 1) {
+                throw new Error('Couldn\'t fusion the stock');
             }
+            await registerOperation(conn, deleteStock.id, 'deleteStock');
+
             await conn.commit();
-            logger.info('FUSION from stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error('Error fusion stock:', error);
+            logger.info('warehouse.fusionStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock merged successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.fusionStock(): Error merging Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.fusionStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error merging Stock', 1, [error]);
         }
     },
 
+    /**
+     * Divides the stock and creates a new stock with quantity = newQuantity.
+     * @param {*} stock: the stock wich will be divided.
+     * @param {*} newQuantity: the quantity that will form the new stock.
+     * In REPEATABLE READ the update statement locks the row that matches with the id.
+    */
     divideStock: async function (conn, stock, newQuantity) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
         await conn.beginTransaction();
         try {
-            let sql = `UPDATE stock SET quantity = quantity - ${newQuantity} WHERE id = ?;`;
-            const fusionStock = await conn.execute(sql, [stock.id]);
-            if (fusionStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t divide the stock');
+            await lockLocation(conn, stock.location_id);
+            await checkStock(conn, stock.id);
+
+            let sql = 'UPDATE stock SET quantity = quantity - ?, version = version + 1 WHERE id = ? AND version = ?';
+            let resultQuery = await conn.execute(sql, [newQuantity, stock.id, stock.version]);
+            if (resultQuery[0].affectedRows !== 1) {
+                throw new Error('The version does not match with the stock.');
             }
+            await registerOperation(conn, stock.id, 'divideStock');
 
             sql = 'INSERT INTO stock (quantity, location_id, product_id, unit_id) VALUES (?, ?, ?, ?);';
-            const insertIntoStock = await conn.execute(sql, [newQuantity, stock.location_id, stock.product_id, stock.unit_id]);
-            if (insertIntoStock[0].affectedRows !== 1) {
+            resultQuery = await conn.execute(sql, [newQuantity, stock.location_id, stock.product_id, stock.unit_id]);
+            if (resultQuery[0].affectedRows !== 1) {
                 throw new Error('Couldn\'t insert values into stock');
             }
+
+            sql = 'SELECT id FROM stock WHERE quantity = ? AND location_id = ? AND product_id = ? AND unit_id = ?';
+            resultQuery = await conn.execute(sql, [stock.quantity, stock.location_id, stock.product_id, stock.unit_id]);
+            if (resultQuery[0].length !== 1) {
+                throw new Error('Couldn\'t find the stock');
+            }
+            await registerOperation(conn, resultQuery[0][0].id, 'createStock');
+
             await conn.commit();
-            logger.info('DIVIDE from stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error('Error dividing stock:', error);
+            logger.info('warehouse.divideStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock divided successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.divideStock(): Error dividing Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.divideStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error dividing Stock', 1, [error]);
         }
     },
 
-    groupStock: async function (conn, column) {
-        let sql = '';
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * @param {*} stock: the row that works as a container/box of the other stock.
+     * @param {*} unitToGroup: is the stock that can be grouped in containers.
+    */
+    groupStock: async function (conn, stock, unitToGroup) {
         await conn.beginTransaction();
         try {
-            sql = `SELECT ${column}, SUM(quantity) AS total_quantity 
-                    FROM stock 
-                    GROUP BY ${column};`;
-            const groupStock = await conn.execute(sql);
-            if (groupStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t group the stock');
-            }
+            await changeUnit(conn, stock, unitToGroup);
+            await registerOperation(conn, stock.id, 'groupStock');
             await conn.commit();
-            logger.info('GRoup stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error('Error grouping stock:', error);
+            logger.info('warehouse.groupStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock grouped successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.groupStock(): Error grouping Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.groupStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error grouping Stock', 1, [error]);
         }
     },
 
-    ungroupStock: async function (conn) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * @param {*} stock: the row that works as a container/box of the other stock.
+     * @param {*} unitToUngroup: is the stock that can be ungrouped.
+    */
+    ungroupStock: async function (conn, stock, unitToUngroup) {
         await conn.beginTransaction();
         try {
-            const sql = 'SELECT * FROM stock';
-            const groupStock = await conn.execute(sql);
-            if (groupStock[0].length <= 0) {
-                throw new Error('Couldn\'t ungroup the stock');
-            }
+            await changeUnit(conn, stock, unitToUngroup);
+            await registerOperation(conn, stock.id, 'ungroupStock');
             await conn.commit();
-            logger.info('Ungroup stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error(error);
+            logger.info('warehouse.ungroupStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Stock ungrouped successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.ungroupStock(): Error ungrouping Stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.ungroupStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error ungrouping Stock', 1, [error]);
         }
     },
 
-    changeStockLocation: async function (conn, origStock, newLocation, quantity) {
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * Changes de location of a stock
+     * UPDATE statement locks the row updated.
+     */
+    changeLocationStock: async function (conn, stock, newLocation) {
         await conn.beginTransaction();
         try {
-            let sql = `UPDATE stock SET quantity = quantity - ${quantity} WHERE id = ?;`;
-            const fusionStock = await conn.execute(sql, [origStock.id]);
-            if (fusionStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t divide the stock');
-            }
+            await lockLocations(conn, newLocation.id, stock.location_id);
+            await checkStock(conn, stock.id);
 
-            sql = 'INSERT INTO stock (quantity, location_id, product_id, unit_id) VALUES (?, ?, ?, ?);';
-            const insertIntoStock = await conn.execute(sql, [quantity, newLocation.id, origStock.product_id, origStock.unit_id]);
-            if (insertIntoStock[0].affectedRows !== 1) {
-                throw new Error('Couldn\'t insert values into stock');
+            const sql = 'UPDATE stock SET location_id = ?, version = version + 1 WHERE id = ? AND version = ?';
+            const resultQuery = await conn.execute(sql, [newLocation.id, stock.id, stock.version]);
+            if (resultQuery[0].affectedRows !== 1) {
+                throw new Error('The version does not match with the stock');
             }
+            await registerOperation(conn, stock.id, 'changeLocationStock');
+
             await conn.commit();
-            logger.info('Change stock location: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error('Error changing stock location:', error);
+            logger.info('warehouse.changeStockLocation(): Transaction committed');
+            return new ApiResult(200, { message: 'Location stock changed successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.changeStockLocation(): Error changing location stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.changeStockLocation(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error changing location stock', 1, [error]);
         }
     },
 
-    countLocationStock: async function (conn, location) {
-        let sql = '';
-        await conn.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    /**
+     * Counts the stock of a location (group by location_id)
+     */
+    countLocationStock: async function (conn, stock) {
         await conn.beginTransaction();
         try {
-            sql = 'SELECT SUM(quantity) AS total_quantity FROM stock WHERE location_id = ? GROUP BY location_id;';
-            const groupStock = await conn.execute(sql, [location.id]);
-            if (groupStock[0].length !== 1) {
-                throw new Error('Couldn\'t group the stock');
+            await lockLocation(conn, location.id);
+
+            const sql = 'SELECT SUM(quantity) AS total_quantity FROM stock WHERE location_id = ? GROUP BY location_id;';
+            const resultQuery = await conn.execute(sql, [stock.location_id]);
+            if (resultQuery[0].length !== 1) {
+                throw new Error('The location does not exist.');
             }
+            await registerOperation(conn, stock.id, 'countLocationStock');
+
             await conn.commit();
-            logger.info('Count location stock: Transaction committed');
-            return true;
-        } catch (error) {
-            logger.error('Error counting location stock:', error);
+            logger.info('warehouse.countLocationStock(): Transaction committed');
+            return new ApiResult(200, { message: 'Location stock counted successfully' }, 1, []);
+        } catch (e) {
+            logger.error('warehouse.countLocationStock(): Error counting location stock: ' + e);
             await conn.rollback();
-            return false;
+            logger.info('warehouse.countLocationStock(): Transaction rolled back');
+            const error = new ApiError('REG01', e.message, '', '');
+            return new ApiResult(500, 'Error counting location stock', 1, [error]);
         }
     }
 };
+
+async function changeUnit (conn, stock, newUnit) {
+    await lockLocation(conn, stock.location_id);
+    await checkStock(conn, stock.id);
+    await checkUnit(conn, newUnit.id);
+
+    const baseUnit = await getBaseUnit(conn, stock);
+    const newQuantity = ((stock.quantity * baseUnit) / newUnit.base_unit);
+    const leftStock = ((stock.quantity * baseUnit) % newUnit.base_unit);
+
+    let sql = 'SELECT * FROM stock WHERE product_id = ? AND unit_id = ?';
+    const stockToMerge = await conn.execute(sql, [stock.product_id, newUnit.id]);
+    if (stockToMerge[0].length === 1) {
+        sql = 'UPDATE stock set quantity = quantity + ?, version = version + 1 WHERE id = ? AND version = ?';
+        const resultQuery = await conn.execute(sql, [newQuantity, stockToMerge[0][0].id, stockToMerge[0][0].version]);
+        if (resultQuery[0].affectedRows !== 1) {
+            throw new Error('The version does not match with the expected stock.');
+        }
+    } else if (stockToMerge[0].length === 0) {
+        sql = 'INSERT INTO stock (quantity, location_id, product_id, unit_id) VALUES (?, ?, ?, ?)';
+        const resultQuery = await conn.execute(sql, [newQuantity, stock.location_id, stock.product_id, newUnit.id]);
+        if (resultQuery[0].affectedRows !== 1) {
+            throw new Error('Couldn\'t insert values into stock.');
+        }
+    }
+
+    sql = 'UPDATE stock set quantity = ?, version = version + 1 WHERE id = ? AND version = ?';
+    const resultQuery = await conn.execute(sql, [leftStock, stock.id, stock.version]);
+    if (resultQuery[0].affectedRows !== 1) {
+        throw new Error('The version does not match with the introduced stock.');
+    }
+}
+
+async function getBaseUnit (conn, stock) {
+    const sql = 'SELECT base_unit FROM unit WHERE id = ?';
+    const resultQuery = await conn.execute(sql, [stock.unit_id]);
+    if (resultQuery[0].length !== 1) {
+        throw new Error('The unit does not exist.');
+    }
+    const quantity = resultQuery[0][0].base_unit;
+    return quantity;
+}
+
+async function checkStock (conn, stockId, message = '') {
+    const sql = 'SELECT * FROM stock WHERE id = ?';
+    const resultQuery = await conn.execute(sql, [stockId]);
+    if (resultQuery[0].length !== 1) {
+        throw new Error(`The ${message}stock does not exist.`);
+    }
+}
+
+async function checkUnit (conn, unitId, message = '') {
+    const sql = 'SELECT * FROM unit WHERE id = ?';
+    const resultQuery = await conn.execute(sql, [unitId]);
+    if (resultQuery[0].length !== 1) {
+        throw new Error(`The ${message}unit does not exist.`);
+    }
+}
+
+/**
+ * @param {*} locationId :the location that will be locked.
+ * The reason for using FOR UPDATE is because it avoids deadlocks by locking the reading (SELECT) of the location. Explanation:
+ * If transaction1 (t1) executes this function and immediately after is executed by transaction2 (t2), then
+ * t2 will wait until t1 is commit or rollback, then t2 will be unlocked and continue the execution.
+ */
+async function lockLocation (conn, locationId) {
+    const sql = 'SELECT * FROM location WHERE id = ? FOR UPDATE';
+    const selectLocation = await conn.execute(sql, [locationId]);
+    if (selectLocation[0].length !== 1) {
+        throw new Error('The location does not exist.');
+    }
+}
+
+async function lockLocations (conn, locationId, locationBId) {
+    const sql = 'SELECT * FROM location WHERE id IN ( ?, ? ) FOR UPDATE';
+    const selectLocation = await conn.execute(sql, [locationId, locationBId]);
+    if (selectLocation[0].length !== 2) {
+        throw new Error('The locations does not exists.');
+    }
+}
+
+async function registerOperation (conn, stockId, operationName) {
+    const date = new Date();
+    let sql = 'SELECT id FROM operation_type WHERE name = ?';
+    let resultQuery = await conn.execute(sql, [operationName]);
+    if (resultQuery[0].length !== 1) {
+        throw new Error('Operation type does not exist.');
+    }
+
+    sql = 'INSERT INTO register (stock_id, operation_id, date) VALUES (?, ?, ?)';
+    resultQuery = await conn.execute(sql, [stockId, resultQuery[0][0].id, date]);
+    if (resultQuery[0].affectedRows !== 1) {
+        throw new Error('Couldn\'t insert into register');
+    }
+}

--- a/app.js
+++ b/app.js
@@ -9,8 +9,10 @@ const database = require('./api/database');
 const uniqid = require('uniqid');
 const tenantdb = require('./api/tenantdb');
 
+const apiDocsV1 = require('./routes/v1/api-docs');
 const indexRouter = require('./routes/index');
 const usersRouter = require('./routes/users');
+const warehouseRouter = require('./routes/warehouse');
 
 /* const nodemailer = require("nodemailer");
 var transporter=null; */
@@ -68,7 +70,8 @@ async function getAllDatabase () {
     try {
         let sql = 'SELECT * FROM tenants ';
         const totalTenants = await conn.execute(sql);
-        if (totalTenants.length !== 2 || totalTenants[0].length === 0) {
+        // if (totalTenants.length !== 2 || totalTenants[0].length === 0) {
+        if (totalTenants.length !== 2) {
             throw new Error('Select * FROM tenants was not successful');
         }
         for (let i = 0; i < totalTenants[0].length; i++) {
@@ -124,6 +127,8 @@ app.use(
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
+app.use('/warehouse', warehouseRouter);
+app.use('/v1/api-docs', apiDocsV1);
 
 /**
  * Generate one uniqueid everytime API is called, to trace the client call

--- a/routes/index.js
+++ b/routes/index.js
@@ -22,7 +22,6 @@ router.post('/login', async function (req, res, next) {
     if (loginResult.errors.length > 0) {
         res.render('login', { title: 'nu+warehouses', message: { type: 'error', text: `${loginResult.data}: ${loginResult.errors[0].message}` } });
     }
-    // const warehouse = require();
     // const conn = loginResult.data.conn;
     res.render('login', { title: 'nu+warehouses' });
 });

--- a/routes/warehouse.js
+++ b/routes/warehouse.js
@@ -1,0 +1,234 @@
+const express = require('express');
+const router = express.Router();
+const logger = require('../api/logger');
+const warehouse = require('../api/warehouse');
+const tenantdb = require('../api/tenantdb');
+
+router.get('/', function (req, res, next) {
+});
+
+router.post('/location', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const result = await await warehouse.createLocation(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.delete('/location', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const result = await warehouse.deleteLocation(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.put('/location', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const sql = 'SELECT version from location where id = ?';
+    const version = await conn.execute(sql, [req.body.id]);
+    req.body.version = version[0][0].version;
+
+    const result = await warehouse.updateLocation(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const result = await warehouse.createStock(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.delete('/stock', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const result = await warehouse.deleteStock(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.put('/stock', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const sql = 'SELECT version from stock where id = ?';
+    const version = await conn.execute(sql, [req.body.id]);
+    req.body.version = version[0][0].version;
+
+    const result = await warehouse.updateStock(conn, req.body);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock/fusion', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const sql = 'SELECT version from stock where id = ?';
+    const version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].version = version[0][0].version;
+
+    const result = await warehouse.fusionStock(conn, req.body[0], req.body[1]);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock/divide', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const sql = 'SELECT version from stock where id = ?';
+    const version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].version = version[0][0].version;
+
+    const result = await warehouse.divideStock(conn, req.body[0], req.body[1].quantity);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock/group', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    let sql = 'SELECT version from stock where id = ?';
+    let version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].version = version[0][0].version;
+
+    sql = 'SELECT quantity from stock where id = ?';
+    version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].quantity = version[0][0].quantity;
+
+    sql = 'SELECT version from unit where id = ?';
+    version = await conn.execute(sql, [req.body[1].id]);
+    req.body[1].version = version[0][0].version;
+
+    const result = await warehouse.groupStock(conn, req.body[0], req.body[1]);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock/ungroup', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    let sql = 'SELECT version from stock where id = ?';
+    let version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].version = version[0][0].version;
+
+    sql = 'SELECT quantity from stock where id = ?';
+    version = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].quantity = version[0][0].quantity;
+
+    sql = 'SELECT version from unit where id = ?';
+    version = await conn.execute(sql, [req.body[1].id]);
+    req.body[1].version = version[0][0].version;
+
+    const result = await warehouse.ungroupStock(conn, req.body[0], req.body[1]);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.post('/stock/change-location', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const sql = 'SELECT version from stock where id = ?';
+    const stock = await conn.execute(sql, [req.body[0].id]);
+    req.body[0].version = stock[0][0].version;
+
+    const result = await warehouse.changeLocationStock(conn, req.body[0], req.body[1]);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+router.get('/stock/count-location', async function (req, res, next) {
+    const conn = await tenantdb.getPromisePool(1).getConnection();
+
+    await conn.execute('set session transaction isolation level repeatable read');
+    const isolationLevel = await conn.execute('SELECT @@transaction_isolation');
+    logger.info(isolationLevel[0][0]['@@transaction_isolation']);
+
+    const result = await warehouse.countLocationStock(conn, req.query);
+    if (result.errors.length === 0) {
+        logger.info(result.data.message);
+    }
+    conn.release();
+    res.render('index', { title: 'nu+warehouses' });
+});
+
+module.exports = router;

--- a/scripts/artillery-stock-changeloc.bat
+++ b/scripts/artillery-stock-changeloc.bat
@@ -1,0 +1,20 @@
+@ echo off
+echo Connection to database...
+echo.
+
+rem get the path to the .env file
+set "env_file=%~dp0..\.env"
+
+rem Read the .env file variables
+for /f "tokens=1,* delims==" %%a in ('type "%env_file%"') do set "%%a=%%b"
+
+rem Connection to mysql using .env variables and execute the statements
+mysql -h localhost -u %DB_USER% -p%DB_PASSWORD% -D %ARTILLERY_TEST_DB% -e ^
+"DELETE FROM register; DELETE FROM stock; DELETE FROM location; DELETE FROM unit; DELETE FROM product;^
+INSERT INTO unit (id, code, description, base_unit) VALUES (1, 'UNIT01' ,'descripcio de prova', 1);^
+INSERT INTO product (id, code, description) VALUES (1, 'PRODUCT01' ,'descripcio de prova');^
+INSERT INTO location (id, code, description) VALUES (1, 'UBIC01', 'description 1'), (2, 'UBIC02', 'description 2'); ^
+INSERT INTO stock (id, quantity, location_id, product_id, unit_id) VALUES (1, 55, 1, 1, 1), (2, 17, 2, 1, 1);"
+
+start cmd /c "artillery run ./test/stock-changeloca.yml"
+start cmd /c "artillery run ./test/stock-changelocb.yml"

--- a/scripts/artillery-stock-group.bat
+++ b/scripts/artillery-stock-group.bat
@@ -1,0 +1,20 @@
+@ echo off
+echo Connection to database...
+echo.
+
+rem get the path to the .env file
+set "env_file=%~dp0..\.env"
+
+rem Read the .env file variables
+for /f "tokens=1,* delims==" %%a in ('type "%env_file%"') do set "%%a=%%b"
+
+rem Connection to mysql and execute the statements
+mysql -h localhost -u %DB_USER% -p%DB_PASSWORD% -D %ARTILLERY_TEST_DB% -e ^
+"DELETE FROM register; DELETE FROM stock;DELETE FROM location; DELETE FROM unit; DELETE FROM product;^
+INSERT INTO unit (id, code, description, base_unit) VALUES (1, 'UNIT01' ,'descripcio de prova', 1), (2, 'UNIT02' ,'descripcio de prova', 10);^
+INSERT INTO product (id, code, description) VALUES (1, 'PRODUCT01' ,'descripcio de prova');^
+INSERT INTO location (id, code, description) VALUES (1, 'UBIC01', 'description 1'), (2, 'UBIC02', 'description 2'); ^
+INSERT INTO `stock` (id, quantity, location_id, product_id, unit_id) VALUES (1, 55, 1, 1, 1), (2, 7, 1, 1, 2);"
+
+start cmd /c "artillery run ./test/stock-group.yml"
+start cmd /c "artillery run ./test/stock-ungroup.yml"

--- a/scripts/db/db_tenant.sql
+++ b/scripts/db/db_tenant.sql
@@ -1,20 +1,23 @@
 CREATE TABLE IF NOT EXISTS `location` (
     `id` SERIAL PRIMARY KEY,
     `code` VARCHAR(100) NOT NULL,
-    `description` VARCHAR(255) NOT NULL
+    `description` VARCHAR(255) NOT NULL,
+    `version` INT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS `unit` (
     `id` SERIAL PRIMARY KEY,
     `code` VARCHAR(100) NOT NULL,
     `description` VARCHAR(255) NOT NULL,
-    `base_unit` INT NOT NULL
+    `base_unit` INT NOT NULL,
+    `version` INT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS `product` (
     `id` SERIAL PRIMARY KEY,
     `code` VARCHAR(100) NOT NULL,
-    `description` VARCHAR(255) NOT NULL
+    `description` VARCHAR(255) NOT NULL,
+    `version` INT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS `stock` (
@@ -23,7 +26,25 @@ CREATE TABLE IF NOT EXISTS `stock` (
     `location_id` BIGINT UNSIGNED NOT NULL,
     `product_id` BIGINT UNSIGNED NOT NULL,
     `unit_id` BIGINT UNSIGNED NOT NULL,
+    `version` INT NOT NULL DEFAULT 0,
     FOREIGN KEY (location_id) REFERENCES location(id),
     FOREIGN KEY (product_id) REFERENCES product(id),
     FOREIGN KEY (unit_id) REFERENCES unit(id)
 );
+
+CREATE TABLE IF NOT EXISTS `operation_type`(
+    `id` SERIAL PRIMARY KEY,
+    `code` VARCHAR(20),
+    `name` VARCHAR(20),
+    `description` VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS `register` (
+    `id` SERIAL PRIMARY KEY,
+    `stock_id` BIGINT UNSIGNED NOT NULL,
+    `operation_id` BIGINT UNSIGNED NOT NULL,
+    `date` DATE,
+    FOREIGN KEY (stock_id) REFERENCES stock(id),
+    FOREIGN KEY (operation_id) REFERENCES operation_type(id)
+);
+

--- a/test/stock-changeloca.yml
+++ b/test/stock-changeloca.yml
@@ -1,0 +1,40 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 1
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Change location stock"
+      - post: 
+          url: "/stock/change-location"
+          json: [
+            {
+              id: 1,
+              location_id: 1,
+              version: 0
+            },
+            {
+              id: 2
+            }
+          ]
+      - post: 
+          url: "/stock/change-location"
+          json: [
+            {
+              id: 1,
+              location_id: 2,
+              version: 0
+            },
+            {
+              id: 1
+            }
+          ]
+      count: 2
+
+# artillery run ./test/stock-changeloca.yml

--- a/test/stock-changelocb.yml
+++ b/test/stock-changelocb.yml
@@ -1,0 +1,40 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 1
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Change location stock"
+      - post: 
+          url: "/stock/change-location"
+          json: [
+            {
+              id: 2,
+              location_id: 2,
+              version: 0
+            },
+            {
+              id: 1
+            }
+          ]
+      - post: 
+          url: "/stock/change-location"
+          json: [
+            {
+              id: 2,
+              location_id: 1,
+              version: 0
+            },
+            {
+              id: 2
+            }
+          ]
+      count: 2
+
+# artillery run ./test/stock-changelocb.yml

--- a/test/stock-divide.yml
+++ b/test/stock-divide.yml
@@ -1,0 +1,29 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 10
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Divide stock"
+      - post: 
+          url: "/stock/divide"
+          json: [
+            {
+              id: 1,
+              location_id: 1,
+              product_id: 1,
+              unit_id: 1,
+              version: 0
+            },
+            {
+              quantity: 2
+            }
+          ]
+      count: 3
+# artillery run ./test/stock-divide.yml

--- a/test/stock-group.yml
+++ b/test/stock-group.yml
@@ -1,0 +1,31 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 10
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Group stock"
+      - post: 
+          url: "/stock/group"
+          json: [
+                {
+                    id: 1,
+                    quantity: 0,
+                    location_id: 1,
+                    product_id: 1,
+                    unit_id: 1,
+                    version: 0
+                },
+                {
+                    id: 2,
+                    base_unit: 10
+                }
+            ]
+      count: 3
+# artillery run ./test/stock-group.yml

--- a/test/stock-ungroup.yml
+++ b/test/stock-ungroup.yml
@@ -1,0 +1,31 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 10
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Ungroup stock"
+      - post: 
+          url: "/stock/ungroup"
+          json: [
+            {
+              id: 2,
+              quantity: 10,
+              location_id: 1,
+              product_id: 1,
+              unit_id: 2,
+              version: 0
+            },
+            {
+              id: 1,
+              base_unit: 1
+            }
+          ]
+      count: 3
+# artillery run ./test/stock-ungroup.yml

--- a/test/stock-update.yml
+++ b/test/stock-update.yml
@@ -1,0 +1,25 @@
+config:
+  # This is a test server run by team Artillery
+  # It's designed to be highly scalable
+  target: http://localhost:3000/warehouse
+  phases:
+    - duration: 15
+      arrivalRate: 1
+      rampTo: 10
+      name: "Case: 1 virtual users to 10 in 15 seconds"
+scenarios:
+  - flow:
+    - loop:
+      - log: "Update stock"
+      - put: 
+          url: "/stock"
+          json: {
+            id: 1,
+            quantity: 2,
+            location_id: 1,
+            product_id: 1,
+            unit_id: 1,
+            version: 0
+          }
+      count: 3
+# artillery run ./test/stock-update.yml


### PR DESCRIPTION
The implementation of the artillery tests and .bat files is to ensure that no deadlocks occur when executing transactions simultaneously, for that purpose we decided to use REPEATABLE READ isolation level and the locking read FOR UPDATE. Furthermore, I did some refactoring in api/warehouse and added two new tables to tenantdb (operation_type and register).